### PR TITLE
Create a state table for sharing information

### DIFF
--- a/source/stencil/private/State/Get-StateTable.ps1
+++ b/source/stencil/private/State/Get-StateTable.ps1
@@ -1,0 +1,22 @@
+
+function Get-StateTable {
+    <#
+    .SYNOPSIS
+        Get the current state table or create a new one if it does not exist
+    #>
+    [CmdletBinding()]
+    param(
+    )
+    begin {
+        Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+    process {
+        if ($null -eq $script:__StateTable) {
+            $script:__StateTable = New-StateTable
+        }
+        $script:__StateTable | Write-Output
+    }
+    end {
+        Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+}

--- a/source/stencil/private/State/New-StateTable.ps1
+++ b/source/stencil/private/State/New-StateTable.ps1
@@ -1,0 +1,78 @@
+
+function New-StateTable {
+    <#
+    .SYNOPSIS
+        Create a structure for maintaining stateTable during stencil invocation
+    #>
+    [CmdletBinding(
+        SupportsShouldProcess
+    )]
+    param(
+    )
+    begin {
+        Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+    process {
+        $stateTable = @{
+            PSTypeName      = 'Stencil.StateTable'
+            Timer           = [System.Diagnostics.Stopwatch]::new()
+            StartTime       = Get-Date 0
+            EndTime         = Get-Date 0
+            SourcePath      = ''
+            DestinationPath = ''
+            CurrentJob      = ''
+            Data            = @{}
+            Defaults        = @{}
+            Environment     = @{}
+            Configuration   = @{}
+            Jobs            = [System.Collections.ArrayList]::new()
+        }
+
+        try {
+            $stateTable.Defaults = Import-Default
+            $stateTable.Environment = [System.Environment]::GetEnvironmentVariables()
+            $stateTable.Configuration = Import-Configuration
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+        $stateObject = [PSCustomObject]$stateTable
+        #-------------------------------------------------------------------------------
+        #region Timer functions
+
+        $stateObject | Add-Member -MemberType ScriptMethod -Name Start -Value {
+            $this.StartTime = Get-Date
+            $this.EndTime = Get-Date 0
+            if ($this.Timer.IsRunning) {
+                $this.Timer.Restart()
+            } else {
+                $this.Timer.Start()
+            }
+        }
+        $stateObject | Add-Member -MemberType ScriptMethod -Name Stop -Value {
+            $this.EndTime = Get-Date
+            if ($this.Timer.IsRunning) {
+                $this.Timer.Stop()
+            } else {
+                $this.Timer.Start()
+            }
+        }
+
+        #endregion Timer functions
+        #-------------------------------------------------------------------------------
+
+        #-------------------------------------------------------------------------------
+        #region Job functions
+
+
+        #endregion Job functions
+        #-------------------------------------------------------------------------------
+
+        if ($PSCmdlet.ShouldProcess('State', 'Create new stateTable')) {
+            $stateObject | Write-Output
+        }
+    }
+    end {
+        Write-Debug "`n$('-' * 80)`n-- End $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
+    }
+}

--- a/source/stencil/public/Invoke-Stencil.ps1
+++ b/source/stencil/public/Invoke-Stencil.ps1
@@ -11,6 +11,11 @@ function Invoke-Stencil {
         )]
         [string]$Path,
 
+        # The stencil.JobInfo to run
+        [Parameter(
+        )]
+        [PSTypeNameAttribute('Stencil.JobInfo')][Object[]]$Job,
+
         # One or more jobs to invoke
         [Parameter(
             ParameterSetName = 'Default',
@@ -28,72 +33,81 @@ function Invoke-Stencil {
     begin {
         Write-Debug "`n$('-' * 80)`n-- Begin $($MyInvocation.MyCommand.Name)`n$('-' * 80)"
 
-        Write-Debug '  loading configuration'
-        $config = Import-Configuration
+        Write-Debug '  Loading configuration'
+        $state = Get-StateTable
+        $state.Start()
         if ($ShowConfig) {
-            $config | Write-Output
+            $state | ConvertTo-Yaml | Write-Output
             break
         }
-        $reg_options = $config.Registry
-
+        $config = $state.Configuration
         <#------------------------------------------------------------------
-          1.  Load the operations registry
+        1.  Load the operations registry
         ------------------------------------------------------------------#>
 
         Reset-StencilOperationRegistry
 
-        Write-Debug "  Loading Operations from $(Resolve-Path $reg_options.Path)"
-        Get-ChildItem @reg_options | ForEach-Object {
+        $options = $config.Registry
+
+        Write-Debug "  Loading Operations from $(Resolve-Path $options.Path)"
+        Get-ChildItem @options | ForEach-Object {
             Write-Verbose "   - Sourcing $($_.BaseName)"
             . $_.FullName
         }
 
         <#------------------------------------------------------------------
-          Set up the context tables
-        ------------------------------------------------------------------#>
-        $script:Defaults = @{}
-        $script:State    = @{}
-        $script:Jobs     = @{}
-    }
-    process {
-        <#------------------------------------------------------------------
         2.  Determine all of the paths that stencils should be loaded from
 
           a. The path(s) given as a parameter
           b. The $StencilPath variable
-              TODO: This should be an environment variable
+              TODO: should this be an environment variable?
           c. The default location ($config.Default.Directory)
           d. The current directory
         ------------------------------------------------------------------#>
         if (-not($PSBoundParameters.ContainsKey('Path'))) {
+            $jobPath = (Join-Path $config.Default.Path.Root $config.Default.Path.Jobs)
             if ($null -ne $StencilPath) {
+                Write-Verbose "`$StencilPath is set to $StencilPath"
                 $Path = ($StencilPath -split ';')
-            } elseif (Test-Path $config.Default.Directory) {
-                $Path = $config.Default.Directory
+            } elseif (Test-Path $jobPath) {
+                $Path = $jobPath
             } else {
                 $Path = (Get-Location).Path
             }
         }
 
         Write-Verbose "  Looking for stencils in $Path"
-        $script:Jobs = Get-Stencil -Path $Path
-        Write-Verbose "  Loaded $($script:Jobs.Count) jobs"
-
-
-        $jobs_to_process = $script:Jobs | Where-Object -Property id -Like $Id
-        if ($jobs_to_process.count -gt 0) {
-            Write-Verbose "  Processing $($jobs_to_process.Count) jobs"
+        Get-Stencil -Path $Path -All | ForEach-Object { [void]$state.Jobs.Add($_) }
+        Write-Verbose "  Loaded $($state.Jobs.Count) jobs"
+    }
+    process {
+        if (-not ($PSBoundParameters.ContainsKey('Job'))) {
+            if (-not ($PSBoundParameters.ContainsKey('Id'))) {
+                throw 'No Job given to process'
+            } else {
+                $possibleJob = $state.Jobs | Where-Object -Property id -Like $Id
+                if ($null -ne $possibleJob) {
+                    try {
+                        $possibleJob | Invoke-StencilJob
+                    } catch {
+                        $PSCmdlet.ThrowTerminatingError($_)
+                    }
+                } else {
+                    throw "No job found with id '$Id'"
+                }
+            }
+        } else {
             try {
-                $jobs_to_process | Invoke-StencilJob
+                $Job | Invoke-StencilJob
             } catch {
                 $PSCmdlet.ThrowTerminatingError($_)
             }
-
-        } else {
-            Write-Information 'No jobs were found to process.'
         }
     }
     end {
+        #TODO: Need a proper shutdown and report process here
+        $state.Stop()
+        $script:__StateTable = $null
         Write-Debug "-- End $($MyInvocation.MyCommand.Name)"
     }
 }


### PR DESCRIPTION
A state table contains runtime and job information, and can be used by jobs to share data.

Closes #22 